### PR TITLE
[FIX] 게시물 조회 엔드포인트 오류 처리

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,18 @@ const users = [
     email: "Connell29@gmail.com",
     password: "password",
   },
+  {
+    id: 3,
+    name: "Eunsong Park",
+    email: "run.eunsong@gmail.com",
+    password: "ohyes",
+  },
+  {
+    id: 4,
+    name: "John Kim",
+    email: "kim@gmail.com",
+    password: "ohno",
+  }
 ]
 
 const posts = [
@@ -29,19 +41,35 @@ const posts = [
     description: "Request/Response와 Stateless!!",
     userId: 1,
   },
+  {
+    id: 3,
+    title: "자바스크립트 입문",
+    description: "야 너두 할수있어 자바스크립트!",
+    userId: 3,
+  },
+  {
+    id: 4,
+    title: "오늘도 수고했어",
+    description: "열심히 공부합시다.",
+    userId: 3,
+  },
 ];
 
 // 기존 하드코딩된 내용을 나와야 할 결과 틀에 맞춰 변환
 let postsList = [];
-for (let i = 0; i < posts.length; i++) {
-  let temp = {
-    userID: posts[i].userId,
-    userName: users[i].name,
-    postingId: posts[i].id,
-    postingTitle: posts[i].title,
-    postingContent: posts[i].description,
-  };
-  postsList.push(temp)
+for (let i = 0; i < users.length; i++) {
+  for (let j = 0; j < posts.length; j++) {
+    if (users[i].id === posts[j].userId) {
+      let temp = {
+        userID: posts[j].userId,
+        userName: users[i].name,
+        postingId: posts[j].id,
+        postingTitle: posts[j].title,
+        postingContent: posts[j].description,
+      };
+      postsList.push(temp)
+    }
+  }
 };
 
 // 데이터 저장은 POST 사용
@@ -56,27 +84,30 @@ const httpRequestListener = function (request, response) {
 
   if (method === 'GET') {
     if (url === '/posting_get') {
+
+      response.writeHead(200, {'Content-Type': 'application/json'});
+      response.end(JSON.stringify({"data" : postsList}));
       
       // 클라이언트에서 내용 받기
-      let body = '';
+      // let body = '';
 
-      request.on('data', (data) => {
-        body += data;
-      });
+      // request.on('data', (data) => {
+      //   body += data;
+      // });
 
-      request.on('end', () => {
-        const list = JSON.parse(body);
+      // request.on('end', () => {
+      //   const list = JSON.parse(body);
 
-        postsList.push({
-          userID: list.userID,
-          userName: list.userName,
-          postingId: list.postingId,
-          postingTitle: list.postingTitle,
-          postingContent: list.postingContent,
-        })
-        response.writeHead(200, {'Content-Type': 'application/json'});
-        response.end(JSON.stringify({"data" : postsList}));
-      })
+      //   postsList.push({
+      //     userID: list.userID,
+      //     userName: list.userName,
+      //     postingId: list.postingId,
+      //     postingTitle: list.postingTitle,
+      //     postingContent: list.postingContent,
+      //   })
+      //   response.writeHead(200, {'Content-Type': 'application/json'});
+      //   response.end(JSON.stringify({"data" : postsList}));
+      // })
     }
   }
 


### PR DESCRIPTION
- users 리스트의 id와 posts 리스트의 userId가 매칭이 안되었던 부분 매칭 처리
- 게시물 추가 등록 기능은 GET이 아닌 추후 POST 에서 추가할 예정 (GET요청을 받을 때는 이미 존재하는 리스트에서 조회만 가능하도록)
- 테스트를 위해 예시들을 하드코딩 배열에 추가

### 작업 목적
app.js 파일에 게시물 조회 엔드포인트 오류를 수정하였습니다.

### 테스트
httpie 클라이언트 도구를 사용하여 정상적으로 동작되는 것을 확인한 후에 pull request를 open하였습니다.
#2 의 테스트에서 미처 확인하지 못한 부분이 있었습니다.

### 기타
commit 내용에도 적어두었지만 게시물 추가 등록 기능은 해당 조회 엔드포인트 (GET)으로 처리하는 것이 아닌 추후에 추가등록 엔드포인트(POST)에 구현하도록 하겠습니다.
테스트를 위해 추가로 예시들을 하드코딩된 리스트에 올려두었습니다.